### PR TITLE
fix: Correct Vercel monorepo routing and serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,8 +18,12 @@
       "dest": "backend/main.py"
     },
     {
+      "src": "/static/(.*)",
+      "dest": "frontend/build/static/$1"
+    },
+    {
       "src": "/(.*)",
-      "dest": "frontend/build/$1"
+      "dest": "frontend/build/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
# Pull Request: Vercel Deployment Fix

## 📋 Description
This PR addresses the ongoing Vercel deployment issues by implementing a correct monorepo configuration. It fixes the `404 Not Found` errors and the `SyntaxError: Unexpected token '<'` by ensuring that Vercel correctly serves both the static frontend and the Python backend.

## 🔗 Related Issues
- Closes #(Issue number for the Vercel deployment bug)

## 🧪 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## 🏗️ Changes Made
- [ ] Backend changes
- [ ] Frontend changes
- [x] Configuration changes
- [ ] Documentation changes

## 🧪 Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (Verified that the Vercel build now runs without errors and the application is accessible)
- [ ] Cross-browser testing (if frontend changes)
- [ ] API testing (if backend changes)

## 📸 Screenshots (if applicable)
## 🔍 Code Review Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code is properly commented
- [ ] No hardcoded values or secrets
- [ ] Error handling is implemented
- [ ] Performance considerations addressed

## 🚀 Deployment Notes
- [ ] Environment variables updated (if needed)
- [ ] Database migrations required (if applicable)
- [ ] Breaking changes documented
- [ ] Rollback plan considered

## 📝 Additional Notes
This PR addresses a critical deployment failure. The updated `vercel.json` file explicitly defines the build process for both the `frontend` and `backend` directories, ensuring all static assets and API routes are served correctly.

## ✅ Ready for Review
- [x] All checks pass
- [x] Ready for code review
- [x] Ready for testing
- [x] Ready for deployment