### PR TITLE
fix: Correct Vercel routing for monorepo

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,11 +19,11 @@
     },
     {
       "src": "/static/(.*)",
-      "dest": "frontend/build/static/$1"
+      "dest": "frontend/static/$1"
     },
     {
       "src": "/(.*)",
-      "dest": "frontend/build/index.html"
+      "dest": "frontend/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
# Pull Request: Correct Vercel Monorepo Deployment

## 📋 Description
This PR addresses the ongoing Vercel deployment failures by correcting the `vercel.json` configuration. The previous routing rules did not correctly map to the files generated during the build process, resulting in `404 Not Found` errors and `SyntaxError: Unexpected token '<'` because the main `index.html` file was being served instead of the expected JavaScript file. This change ensures Vercel serves the correct assets and the single-page application (SPA).

## 🔗 Related Issues
- Closes #(issue number)

## 🧪 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## 🏗️ Changes Made
- [ ] Backend changes
- [ ] Frontend changes
- [ ] Database changes
- [x] Configuration changes
- [ ] Documentation changes

## 🧪 Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (The fix was verified by pushing the changes and observing a successful Vercel deployment where the application loads correctly.)
- [ ] Cross-browser testing (if frontend changes)
- [ ] API testing (if backend changes)

## 📸 Screenshots (if applicable)
<!-- Add screenshots here -->

## 🔍 Code Review Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is properly commented
- [x] No hardcoded values or secrets
- [x] Error handling is implemented
- [x] Performance considerations addressed

## 🚀 Deployment Notes
- [ ] Environment variables updated (if needed)
- [ ] Database migrations required (if applicable)
- [ ] Breaking changes documented
- [ ] Rollback plan considered

## 📝 Additional Notes
The core of the fix was updating the `routes` in `vercel.json` to reflect the actual file paths within the Vercel deployment output. Specifically, the `dest` paths were changed to point to the `frontend/` directory, where the built files and static assets are located.

## ✅ Ready for Review
- [x] All checks pass
- [x] Ready for code review
- [x] Ready for testing
- [x] Ready for deployment