### PR TITLE
fix: Add explicit routing for manifest file

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -26,6 +26,10 @@
       "dest": "/frontend/favicon.ico"
     },
     {
+      "src": "/site.webmanifest",
+      "dest": "/frontend/site.webmanifest"
+    },
+    {
       "src": "/(.*)",
       "dest": "frontend/index.html"
     }


### PR DESCRIPTION
# Pull Request: Fix Manifest File Routing

## 📋 Description
This PR resolves the `SyntaxError: Unexpected token '<'` that was occurring for the `site.webmanifest` file on production deployments. The previous `vercel.json` file did not have a specific routing rule for this file, causing Vercel to serve the `index.html` instead of the correct manifest file. This change adds a dedicated route to ensure the manifest is correctly served.

## 🔗 Related Issues
- Closes #(issue number)

## 🧪 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## 🏗️ Changes Made
- [ ] Backend changes
- [ ] Frontend changes
- [ ] Database changes
- [x] Configuration changes
- [ ] Documentation changes

## 🧪 Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (Verified that the application loads without console errors and the manifest file is correctly served.)
- [ ] Cross-browser testing (if frontend changes)
- [ ] API testing (if backend changes)

## 📸 Screenshots (if applicable)
## 🔍 Code Review Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code is properly commented
- [ ] No hardcoded values or secrets
- [x] Error handling is implemented
- [x] Performance considerations addressed

## 🚀 Deployment Notes
- [ ] Environment variables updated (if needed)
- [ ] Database migrations required (if applicable)
- [ ] Breaking changes documented
- [ ] Rollback plan considered

## 📝 Additional Notes
The core of this fix is the addition of a new route: `"src": "/site.webmanifest", "dest": "/frontend/site.webmanifest"`, which correctly maps the browser request to the file's location in the repository.

## ✅ Ready for Review
- [x] All checks pass
- [x] Ready for code review
- [x] Ready for testing
- [x] Ready for deployment