### PR TITLE
feat: Update icon paths in frontend to use correct sub-directory

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,8 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
@@ -12,10 +10,10 @@
       content="FindLand Africa - Real Estate Bridging Loan Platform"
     />
     <title>FindLand Africa - MVP</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon_io/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon_io/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon_io/favicon-16x16.png">
+    <link rel="manifest" href="/favicon_io/site.webmanifest">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -3,22 +3,22 @@
   "short_name": "FindLand",
   "icons": [
     {
-      "src": "/android-chrome-192x192.png",
+      "src": "/favicon_io/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/android-chrome-512x512.png",
+      "src": "/favicon_io/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "/favicon-32x32.png",
+      "src": "/favicon_io/favicon-32x32.png",
       "sizes": "32x32",
       "type": "image/png"
     },
     {
-      "src": "/favicon-16x16.png",
+      "src": "/favicon_io/favicon-16x16.png",
       "sizes": "16x16",
       "type": "image/png"
     }


### PR DESCRIPTION
# Pull Request: Correct Icon Paths for Deployment

## 📋 Description
This PR permanently fixes the favicon and manifest icon loading errors by directly correcting the file paths in the frontend code. Instead of relying on complex Vercel routing rules, `index.html` and `site.webmanifest` now correctly reference icon files from their proper sub-directory (`/favicon_io/`). This approach is more robust and maintains cleaner code.

## 🔗 Related Issues
- Closes #(issue number)

## 🧪 Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## 🏗️ Changes Made
- [ ] Backend changes
- [x] Frontend changes
- [ ] Database changes
- [ ] Configuration changes
- [ ] Documentation changes

## 🧪 Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed (Verified that all favicons and manifest icons now load correctly on the live site without any console errors.)
- [ ] Cross-browser testing (if frontend changes)
- [ ] API testing (if backend changes)

## 📸 Screenshots (if applicable)
## 🔍 Code Review Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Code is properly commented
- [ ] No hardcoded values or secrets
- [x] Error handling is implemented
- [x] Performance considerations addressed

## 🚀 Deployment Notes
- [ ] Environment variables updated (if needed)
- [ ] Database migrations required (if applicable)
- [ ] Breaking changes documented
- [ ] Rollback plan considered

## 📝 Additional Notes
This change simplifies the Vercel configuration by making the frontend paths correct by default. The `vercel.json` file can now be cleaned up to include only the necessary routing rules.

## ✅ Ready for Review
- [x] All checks pass
- [x] Ready for code review
- [x] Ready for testing
- [x] Ready for deployment